### PR TITLE
Fix reliability and PHP 8.2+/WHMCS 9 compatibility bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Allows you to use Razorpay payment gateway with the WHMCS Store.
 
 ## Description
 
-​This is the Razorpay payment gateway plugin for WHMCS. Allows Indian merchants to accept credit cards, debit cards, netbanking and wallet payments with the WHMCS store. It uses a seamless integration, allowing the customer to pay on your website without being redirected away from your WHMCS website.
+​This is the Razorpay payment gateway plugin for WHMCS. Allows merchants to accept credit cards, debit cards, netbanking, wallets, UPI and international payment methods with the WHMCS store. It uses a seamless integration, allowing the customer to pay on your website without being redirected away from your WHMCS website.
 
-## Downloads: [whmcs-6 / whmcs-7 / whmcs-8][6] [whmcs-5][5]
+## Downloads: [whmcs-6 / whmcs-7 / whmcs-8 / whmcs-9][6] [whmcs-5][5]
 
 ## Installation
 
@@ -16,7 +16,7 @@ Allows you to use Razorpay payment gateway with the WHMCS Store.
 
 ## Branches
 
- - Use the `master` branch if you are on WHMCS 6 or WHMCS 7 or WHMCS 8
+ - Use the `master` branch if you are on WHMCS 6, WHMCS 7, WHMCS 8 or WHMCS 9
  - Use the `whmcs-5` branch if you are on WHMCS 5
 
 ## Configuration

--- a/modules/gateways/razorpay.php
+++ b/modules/gateways/razorpay.php
@@ -211,7 +211,7 @@ function razorpay_link($params)
     // Invoice Parameters
     $invoiceId = $params['invoiceid'];
     $description = $params["description"];
-    $amount = $params['amount'] * 100; // Required to be converted to Paisa.
+    $amount = (int) round($params['amount'] * 100); // Required to be converted to Paisa.
     $currencyCode = $params['currency'];
 
     // Client Parameters

--- a/modules/gateways/razorpay/razorpay-sdk/src/Request.php
+++ b/modules/gateways/razorpay/razorpay-sdk/src/Request.php
@@ -11,9 +11,9 @@ use Razorpay\Api\Errors\ErrorCode;
 
 // Available since PHP 5.5.19 and 5.6.3
 // https://git.io/fAMVS | https://secure.php.net/manual/en/curl.constants.php
-if (defined('CURL_SSLVERSION_TLSv1_1') === false)
+if (defined('CURL_SSLVERSION_TLSv1_2') === false)
 {
-    define('CURL_SSLVERSION_TLSv1_1', 5);
+    define('CURL_SSLVERSION_TLSv1_2', 6);
 }
 
 /**
@@ -62,7 +62,10 @@ class Request
 
     public function setCurlSslOpts($curl)
     {
-        curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1);
+        // Razorpay's API (and PCI-DSS generally) requires TLS 1.2+.
+        // TLS 1.1 is now rejected by most gateways, which previously caused
+        // every API call made by this SDK to fail outright.
+        curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     }
 
     /**

--- a/modules/gateways/razorpay/razorpay-sdk/src/Webhook.php
+++ b/modules/gateways/razorpay/razorpay-sdk/src/Webhook.php
@@ -30,7 +30,7 @@ class Webhook extends Entity
      *
      * @return Webhooks
      */
-    public function edit($attributes = array(), $id)
+    public function edit($id, $attributes = array())
     {
         $url = $this->getEntityUrl() . $id;
 

--- a/modules/gateways/razorpay/razorpay-webhook.php
+++ b/modules/gateways/razorpay/razorpay-webhook.php
@@ -5,9 +5,11 @@ require_once __DIR__ . '/../../../init.php';
 require_once __DIR__ . '/../../../includes/gatewayfunctions.php';
 require_once __DIR__ . '/../../../includes/invoicefunctions.php';
 require_once __DIR__ . '/razorpay-sdk/Razorpay.php';
+require_once __DIR__ . '/rzpordermapping.php';
 
 use Razorpay\Api\Api;
 use Razorpay\Api\Errors;
+use Illuminate\Database\Capsule\Manager as Capsule;
 
 /**
  * Event constants
@@ -89,7 +91,7 @@ if ($enabled === 'on' and
         switch ($data['event'])
         {
             case ORDER_PAID:
-                return orderPaid($data, $gatewayParams);
+                return orderPaid($data, $gatewayParams, $gatewayModuleName);
 
             default:
                 return;
@@ -103,7 +105,7 @@ if ($enabled === 'on' and
  *
  * @param array $data
  */
-function orderPaid(array $data, $gatewayParams)
+function orderPaid(array $data, $gatewayParams, $gatewayModuleName)
 {
     // We don't process subscription/invoice payments here
     if (isset($data['payload']['payment']['entity']['invoice_id']) === true)
@@ -120,16 +122,22 @@ function orderPaid(array $data, $gatewayParams)
 
     // Validate Callback Invoice ID.
     $merchant_order_id = checkCbInvoiceID($orderId, $gatewayParams['name']);
-    
+
     // Check Callback Transaction ID.
     checkCbTransID($razorpayPaymentId);
 
-    $orderTableId = mysql_fetch_assoc(select_query('tblorders', 'id', array("invoiceid"=>$orderId)));
+    $orderTableRow = Capsule::table('tblorders')->select('id')->where('invoiceid', $orderId)->first();
+
+    if (isset($orderTableRow) === false)
+    {
+        logTransaction($gatewayParams['name'], "order not found for invoice ".$orderId, "INFO");
+        return;
+    }
 
     $command = 'GetOrders';
 
     $postData = array(
-        'id' => $orderTableId['id'],
+        'id' => $orderTableRow->id,
     );
 
     $order = localAPI($command, $postData);
@@ -169,7 +177,7 @@ function orderPaid(array $data, $gatewayParams)
         # Apply Payment to Invoice: invoiceid, transactionid, amount paid, fees, modulename
         $orderAmount=$order['orders']['order'][0]['amount'];
         
-        addInvoicePayment($orderId, $razorpayPaymentId, $orderAmount, 0, $gatewayParams["name"]);
+        addInvoicePayment($orderId, $razorpayPaymentId, $orderAmount, 0, $gatewayModuleName);
         logTransaction($gatewayParams["name"], $log, "Successful"); # Save to Gateway Log: name, data array, status
     }
     else

--- a/modules/gateways/razorpay/razorpay.php
+++ b/modules/gateways/razorpay/razorpay.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/rzpordermapping.php';
 
 use Razorpay\Api\Api;
 use Razorpay\Api\Errors;
+use Illuminate\Database\Capsule\Manager as Capsule;
 
 // Detect module name from filename.
 $gatewayModuleName = 'razorpay';
@@ -30,8 +31,8 @@ if (!$gatewayParams['type'])
 }
 
 // Retrieve data returned in payment gateway callback
-$merchant_order_id   = (isset($_POST['merchant_order_id']) === true) ? $_POST['merchant_order_id'] : $_GET['merchant_order_id'];
-$razorpay_payment_id = $_POST['razorpay_payment_id'];
+$merchant_order_id   = (isset($_POST['merchant_order_id']) === true) ? $_POST['merchant_order_id'] : (isset($_GET['merchant_order_id']) === true ? $_GET['merchant_order_id'] : null);
+$razorpay_payment_id = (isset($_POST['razorpay_payment_id']) === true) ? $_POST['razorpay_payment_id'] : null;
 
 // Validate Callback Invoice ID.
 $merchant_order_id = checkCbInvoiceID($merchant_order_id, $gatewayParams['name']);
@@ -40,27 +41,30 @@ $merchant_order_id = checkCbInvoiceID($merchant_order_id, $gatewayParams['name']
 * Fetch amount to verify transaction
 */
 # Fetch invoice to get the amount and userid
-$result = mysql_fetch_assoc(select_query('tblinvoices', '*', array("id"=>$merchant_order_id)));
+$result = Capsule::table('tblinvoices')->where('id', $merchant_order_id)->first();
 
 #check whether order is already paid or not, if paid then redirect to complete page
-if($result['status'] === 'Paid')
+if (isset($result) === true and $result->status === 'Paid')
 {
     header("Location: ".$gatewayParams['systemurl']."/viewinvoice.php?id=" . $merchant_order_id); // nosemgrep : php.lang.security.non-literal-header.non-literal-header
-    
+
     exit;
 }
 
-$amount = $result['total'];
+$amount = $result->total;
 
 $error = "";
 
 try
 {
+    // Check Callback Transaction ID.
+    checkCbTransID($razorpay_payment_id);
+
     verifySignature($merchant_order_id, $_POST, $gatewayParams);
 
     # Successful
     # Apply Payment to Invoice: invoiceid, transactionid, amount paid, fees, modulename
-    addInvoicePayment($merchant_order_id, $razorpay_payment_id, $amount, 0, $gatewayParams["name"]);
+    addInvoicePayment($merchant_order_id, $razorpay_payment_id, $amount, 0, $gatewayModuleName);
 
     logTransaction($gatewayParams["name"], $_POST, "Successful"); # Save to Gateway Log: name, data array, status
 }
@@ -70,7 +74,7 @@ catch (Errors\SignatureVerificationError $e)
 
     # Unsuccessful
     # Save to Gateway Log: name, data array, status
-    logTransaction($gatewayParams["name"], $_POST, "Unsuccessful-".$error . ". Please check razorpay dashboard for Payment id: ".$_POST['razorpay_payment_id']);
+    logTransaction($gatewayParams["name"], $_POST, "Unsuccessful-".$error . ". Please check razorpay dashboard for Payment id: ".$razorpay_payment_id);
 }
 
 header("Location: ".$gatewayParams['systemurl']."/viewinvoice.php?id=" . $merchant_order_id); // nosemgrep : php.lang.security.non-literal-header.non-literal-header
@@ -95,8 +99,8 @@ function verifySignature(int $order_no, array $response, $gatewayParams)
     $api = getApiInstance($gatewayParams['keyId'], $gatewayParams['keySecret']);
 
     $attributes = array(
-        RAZORPAY_PAYMENT_ID => $response[RAZORPAY_PAYMENT_ID],
-        RAZORPAY_SIGNATURE  => $response[RAZORPAY_SIGNATURE],
+        RAZORPAY_PAYMENT_ID => (isset($response[RAZORPAY_PAYMENT_ID]) === true) ? $response[RAZORPAY_PAYMENT_ID] : "",
+        RAZORPAY_SIGNATURE  => (isset($response[RAZORPAY_SIGNATURE]) === true) ? $response[RAZORPAY_SIGNATURE] : "",
     );
 
     $sessionKey = getOrderSessionKey($order_no);
@@ -111,16 +115,8 @@ function verifySignature(int $order_no, array $response, $gatewayParams)
         logTransaction($gatewayParams['name'], $sessionKey, "Session not found");
         try
         {
-            if (isset($order_no) === true)
-            {
-                $rzpOrderMapping = new RZPOrderMapping($gatewayParams['name']);
-                $razorpayOrderId = $rzpOrderMapping->getRazorpayOrderID($order_no);
-            }
-            else
-            {
-                $error = "merchant_order_id is not set";
-                logTransaction($gatewayParams['name'], $error, "Validation Failure");
-            }
+            $rzpOrderMapping = new RZPOrderMapping($gatewayParams['name']);
+            $razorpayOrderId = $rzpOrderMapping->getRazorpayOrderID($order_no);
         }
         catch (Exception $e)
         {
@@ -128,6 +124,6 @@ function verifySignature(int $order_no, array $response, $gatewayParams)
         }
     }
 
-    $attributes[RAZORPAY_ORDER_ID] = $razorpayOrderId;
+    $attributes[RAZORPAY_ORDER_ID] = (isset($razorpayOrderId) === true) ? $razorpayOrderId : "";
     $api->utility->verifyPaymentSignature($attributes);
 }

--- a/modules/gateways/razorpay/rzpordermapping.php
+++ b/modules/gateways/razorpay/rzpordermapping.php
@@ -68,7 +68,7 @@ class RZPOrderMapping
             ->orderBy('id', 'desc')
             ->first();
 
-        return $result->razorpay_order_id;
+        return (isset($result) === true) ? $result->razorpay_order_id : null;
     }
 
     function validateMerchantOrderID($merchant_order_id)


### PR DESCRIPTION
## Summary

Several long-standing bugs in this module were surfaced by auditing the open issues and testing against current WHMCS (9.0, requires PHP 8.2+) developer guidelines. None of these are new features — all are correctness/compatibility fixes to existing flows.

- **Fatal on modern PHP**: `modules/gateways/razorpay/razorpay.php` and `razorpay-webhook.php` called `mysql_fetch_assoc(select_query(...))`. `mysql_fetch_assoc()` is a native PHP function removed from PHP core in PHP 7.0. WHMCS 9 requires PHP 8.2+, so this call would fatal with "Call to undefined function". Replaced with the Capsule ORM already used elsewhere in this module (`rzpordermapping.php`).
- **TLS 1.1 forced on every API call** (`razorpay-sdk/src/Request.php`): the SDK explicitly pinned `CURLOPT_SSLVERSION` to TLS 1.1. TLS 1.1 is rejected by most gateways/CDNs today, which silently breaks the underlying cURL request. This looks like the root cause behind a number of long-standing "invoice not getting paid" / "payment failed" reports (e.g. #26, #29, #33, #62, #74). Bumped to TLS 1.2.
- **Wrong gateway module name passed to `addInvoicePayment()`**: both handlers passed `$gatewayParams['name']` (the friendly display name "Razorpay") instead of the internal module system name `razorpay`. Fixes blank "Payment Method" values reported in #36, and other internal WHMCS lookups keyed on the module name.
- **Null-pointer risk in `RZPOrderMapping::getRazorpayOrderID()`**: dereferenced a property on the Capsule query result without checking it was found, likely contributing to the recurring "Either razorpay_order_id ... must be present" verification failures (#26, #38, #62).
- **Missing duplicate-transaction protection**: added `checkCbTransID()` to both the callback and webhook handlers, per current WHMCS gateway module guidance (https://developers.whmcs.com/payment-gateways/callbacks/), to guard against double-processing on retries/replays.
- **Inconsistent amount rounding**: order creation used `(int) round($amount * 100)` while the checkout.js form used raw `$amount * 100` with no rounding/cast, causing floating-point drift and "Amount Mismatch" errors (#40, #72). Both paths now round identically.
- **PHP 8 warnings**: hardened `$_GET`/`$_POST` access with `isset()` checks instead of direct array access.
- **PHP 8 deprecation**: fixed `Webhook::edit()` parameter order (optional parameter was declared before a required one).
- Updated README to mention WHMCS 9 support and corrected wording that implied Razorpay/this module only supports Indian merchants (Razorpay supports international payment methods too).

## Test plan

- [x] `php -l` (PHP 8.5) passes clean on every file in the repo, including all changed files.
- [x] Reviewed the diff for behavioral equivalence outside the specific bug being fixed.
- [ ] Manual end-to-end test against a live WHMCS 9 + PHP 8.2/8.3 install (I don't have one available in this environment — recommend the team runs through a full pay-now → webhook → refund-free happy path plus a duplicate-callback replay before merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)